### PR TITLE
[update] cycle_focused_tags.py, Fix typo.

### DIFF
--- a/src/cycle_focused_tags.py
+++ b/src/cycle_focused_tags.py
@@ -18,7 +18,7 @@ except:
     Adjust the path of /usr/share/river-protocols/ as approriate for your installation.
 '''
 
-    print(errtxt)
+    print(errtext)
     quit()
 
 status_manager = None


### PR DESCRIPTION
I feel extremely stupid sending this patch, but it led to a crash so here we are.