### PR TITLE
Add support for excluding tags

### DIFF
--- a/riverwm_utils/riverwm_utils.py
+++ b/riverwm_utils/riverwm_utils.py
@@ -86,6 +86,7 @@ class Output:
         '''Handle Event'''
         self.focused_tags = tags
 
+
 class Seat:
     '''Represtents a wayland seat'''
     def __init__(self):
@@ -134,6 +135,7 @@ def registry_handle_global(registry, wid, interface, version):
             SEAT = Seat()
             SEAT.wl_seat = registry.bind(wid, WlSeat, version)
 
+
 def check_direction(direction):
     '''Check validity of direction argument'''
     dir_char = direction[0].lower()
@@ -142,6 +144,7 @@ def check_direction(direction):
 
     return dir_char
 
+
 def check_n_tags(n_tags):
     '''Check validity of direction argument'''
     i_n_tags = int(n_tags)
@@ -149,6 +152,7 @@ def check_n_tags(n_tags):
         raise argparse.ArgumentTypeError(f'Invalid max number of tags: {n_tags}')
 
     return i_n_tags
+
 
 def parse_command_line() -> argparse.Namespace:
     '''Read commanline arguments'''
@@ -167,6 +171,7 @@ def parse_command_line() -> argparse.Namespace:
               'between 1 and 32 inclusive.')
     )
     return parser.parse_args()
+
 
 def cycle_focused_tags():
     '''Shift to next or previous tags'''
@@ -200,7 +205,7 @@ def cycle_focused_tags():
     display.roundtrip()
     tags = SEAT.focused_output.focused_tags
     new_tags = 0
-    last_tag = 1 << (args.n_tags-1)
+    last_tag = 1 << (args.n_tags - 1)
     if args.direction == 'n':
         # If last tag is set => unset it and set first bit on new_tags
         if (tags & last_tag) != 0:

--- a/riverwm_utils/riverwm_utils.py
+++ b/riverwm_utils/riverwm_utils.py
@@ -166,10 +166,6 @@ def parse_command_line() -> argparse.Namespace:
               'to the last tag from the first tag. Should be and integer '
               'between 1 and 32 inclusive.')
     )
-    parser.add_argument(
-        '--skip-unoccupied', '-s', action='store_true', default=False,
-        help='Skip tags with no views.'
-    )
     return parser.parse_args()
 
 def cycle_focused_tags():


### PR DESCRIPTION
This is needed so cycling tags works with a scratch buffer, see: https://codeberg.org/river/wiki/src/branch/master/pages/Scratchpad-and-Sticky.md