### PR TITLE
 Fix skip-empty & skip-occupied options with all-outputs enabled

### DIFF
--- a/riverwm_utils/riverwm_utils.py
+++ b/riverwm_utils/riverwm_utils.py
@@ -320,9 +320,15 @@ def cycle_focused_tags():
     prepare_display(display)
 
     used_tags = (1 << args.n_tags) - 1
+
     tags = SEAT.focused_output.focused_tags & used_tags
-    view_tags = SEAT.focused_output.view_tags
-    occupied_tags = get_occupied_tags(view_tags) & used_tags
+    if args.all_outputs and len(OUTPUTS) > 1:
+        occupied_tags = 0
+        for output in OUTPUTS:
+            occupied_tags |= get_occupied_tags(output.view_tags) & used_tags
+    else:
+        occupied_tags = get_occupied_tags(SEAT.focused_output.view_tags) & used_tags
+
     if args.debug:
         print(f'occ 0b{occupied_tags:032b}')
 

--- a/riverwm_utils/riverwm_utils.py
+++ b/riverwm_utils/riverwm_utils.py
@@ -287,8 +287,8 @@ def get_new_tags(cli_args: argparse.Namespace, tags: int,
             if (tags & last_tag) != 0:
                 tags ^= last_tag
                 new_tags = 1
-            else:
-                new_tags |= (tags << 1)
+
+            new_tags |= (tags << 1)
 
         else:
             # If lowest bit is set (first tag) => unset it and set
@@ -296,8 +296,8 @@ def get_new_tags(cli_args: argparse.Namespace, tags: int,
             if (tags & 1) != 0:
                 tags ^= 1
                 new_tags = last_tag
-            else:
-                new_tags |= (tags >> 1)
+
+            new_tags |= (tags >> 1)
 
         tags = new_tags
         i += 1

--- a/riverwm_utils/riverwm_utils.py
+++ b/riverwm_utils/riverwm_utils.py
@@ -287,8 +287,8 @@ def get_new_tags(cli_args: argparse.Namespace, tags: int,
             if (tags & last_tag) != 0:
                 tags ^= last_tag
                 new_tags = 1
-
-            new_tags |= (tags << 1)
+            else:
+                new_tags |= (tags << 1)
 
         else:
             # If lowest bit is set (first tag) => unset it and set
@@ -296,8 +296,8 @@ def get_new_tags(cli_args: argparse.Namespace, tags: int,
             if (tags & 1) != 0:
                 tags ^= 1
                 new_tags = last_tag
-
-            new_tags |= (tags >> 1)
+            else:
+                new_tags |= (tags >> 1)
 
         tags = new_tags
         i += 1


### PR DESCRIPTION
Fix two issues, one looks unrelated to multiple outputs, although I only managed to redo it with multiple outputs.

The other is that occupied_tags should check all outputs when `--all-outpurs` is used.