### PR TITLE
Fix eternal loop with --skip-occupied and all outputs occupied

### DIFF
--- a/riverwm_utils/riverwm_utils.py
+++ b/riverwm_utils/riverwm_utils.py
@@ -283,14 +283,16 @@ def get_new_tags(cli_args: argparse.Namespace,
             ):
         return tags
 
+    test = 0
     i = 0
     initial_tags = tags
     last_tag = 1 << (cli_args.n_tags - 1)
     while True:
-        if i >= cli_args.n_tags:
+        if test >= cli_args.n_tags:
             # Looped over all tags. Something is wrong, bail out
             print('Warning looped over all tags')
             return initial_tags
+        test += 1
 
         new_tags = 0
         if cli_args.n_cycle > 0:


### PR DESCRIPTION
Fix eternal loop resulting in high CPU usage when all desktops were occupied.

Checking for `i` wasn't correct as continue statements may run before it's incremented.

---

Note the `while True` maybe be replaced by `for _ in range(cli_args.n_tags)` with the slight advantage that there is no need to increment a value inline. Somewhat personal preference though.